### PR TITLE
feat: post info template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ auto encode new anime episode, driven by [**FinalRip**](https://github.com/Tenso
 
 [![codecov](https://codecov.io/gh/TensoRaws/AnimePipeline/graph/badge.svg?token=CtgLouRy8u)](https://codecov.io/gh/TensoRaws/AnimePipeline)
 [![CI-test](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test.yml)
+[![CI-test-cli](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test-cli.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test-cli.yml)
 [![Docker Build CI](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-docker.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-docker.yml)
 [![Release](https://github.com/TensoRaws/AnimePipeline/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/animepipeline.svg)](https://badge.fury.io/py/animepipeline)

--- a/animepipeline/loop.py
+++ b/animepipeline/loop.py
@@ -13,7 +13,7 @@ from animepipeline.pool import AsyncTaskExecutor
 from animepipeline.post import TGChannelSender
 from animepipeline.rss import TorrentInfo, parse_nyaa
 from animepipeline.store import AsyncJsonStore, TaskStatus
-from animepipeline.template import get_telegram_text
+from animepipeline.template import PostTemplate, get_telegram_text
 
 
 class TaskInfo(TorrentInfo):
@@ -264,9 +264,22 @@ class Loop:
 
         self.qbittorrent_manager.add_torrent(torrent_hash=torrent_file_hash, torrent_file_path=torrent_file_save_path)
 
-        logger.info(f"Post to Telegram Channel for {task_info.name} EP {task_info.episode}")
+        logger.info(f"Generate all post info files for {task_info.name} EP {task_info.episode} ...")
 
-        finalrip_downloaded_path = Path(task_info.download_path) / task_status.finalrip_downloaded_path
+        post_template = PostTemplate(
+            video_path=finalrip_downloaded_path,
+            bangumi_url=task_info.bangumi,  # type: ignore
+            chinese_name=task_info.translation,
+            uploader="TensoRaws",
+        )
+
+        post_template.save(
+            html_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".html"),
+            markdown_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".md"),
+            bbcode_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".txt"),
+        )
+
+        logger.info(f"Post to Telegram Channel for {task_info.name} EP {task_info.episode} ...")
 
         if self.tg_channel_sender is None:
             logger.info("Telegram Channel Sender is not enabled. Skip upload.")

--- a/animepipeline/loop.py
+++ b/animepipeline/loop.py
@@ -13,6 +13,7 @@ from animepipeline.pool import AsyncTaskExecutor
 from animepipeline.post import TGChannelSender
 from animepipeline.rss import TorrentInfo, parse_nyaa
 from animepipeline.store import AsyncJsonStore, TaskStatus
+from animepipeline.template import get_telegram_text
 
 
 class TaskInfo(TorrentInfo):
@@ -270,9 +271,13 @@ class Loop:
         if self.tg_channel_sender is None:
             logger.info("Telegram Channel Sender is not enabled. Skip upload.")
         else:
-            await self.tg_channel_sender.send_text(
-                text=f"{task_info.translation} | EP {task_info.episode} | {finalrip_downloaded_path.name} | hash: {torrent_file_hash}"
+            tg_text = get_telegram_text(
+                chinese_name=task_info.translation,
+                episode=task_info.episode,
+                file_name=finalrip_downloaded_path.name,
+                torrent_file_hash=torrent_file_hash,
             )
+            await self.tg_channel_sender.send_text(text=tg_text)
 
         task_status.posted = True
         await self.json_store.update_task(task_info.hash, task_status)

--- a/animepipeline/template/__init__.py
+++ b/animepipeline/template/__init__.py
@@ -1,1 +1,3 @@
-from animepipeline.template.mediainfo import gen_media_info_block  # noqa
+from animepipeline.template.mediainfo import get_media_info_block  # noqa
+from animepipeline.template.bangumi import get_bangumi_info  # noqa
+from animepipeline.template.template import get_telegram_text  # noqa

--- a/animepipeline/template/__init__.py
+++ b/animepipeline/template/__init__.py
@@ -1,0 +1,1 @@
+from animepipeline.template.mediainfo import gen_media_info_block  # noqa

--- a/animepipeline/template/__init__.py
+++ b/animepipeline/template/__init__.py
@@ -1,3 +1,3 @@
 from animepipeline.template.mediainfo import get_media_info_block  # noqa
 from animepipeline.template.bangumi import get_bangumi_info  # noqa
-from animepipeline.template.template import get_telegram_text  # noqa
+from animepipeline.template.template import get_telegram_text, PostTemplate  # noqa

--- a/animepipeline/template/bangumi.py
+++ b/animepipeline/template/bangumi.py
@@ -1,0 +1,44 @@
+from typing import Optional, Tuple
+
+import httpx
+from tenacity import retry, stop_after_attempt, wait_random
+
+
+@retry(wait=wait_random(min=3, max=5), stop=stop_after_attempt(5))
+def get_bangumi_info(bangumi_url: str, chinese_name: Optional[str] = None) -> Tuple[str, str]:
+    """
+    Get bangumi info, first is summary, second is chinese name.
+
+    :param bangumi_url: Bangumi URL
+    :param chinese_name: Bangumi Chinese name. When it is None, it will auto fetch from bangumi.
+    """
+    summary = "!!!!!Fetch failed!!!!!"
+
+    if bangumi_url[-1] == "/":
+        bangumi_url = bangumi_url[:-1]
+
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        "Accept": "*/*",
+        "Host": "api.bgm.tv",
+        "Connection": "keep-alive",
+    }
+
+    with httpx.Client(headers=headers, timeout=20) as client:
+        response = client.get(bangumi_url)
+        response.raise_for_status()
+
+        res = response.json()
+
+        summary = res["summary"]
+
+        if chinese_name is None:
+            try:
+                chinese_name = res["name_cn"]
+            except Exception:
+                chinese_name = res["name"]
+
+            if chinese_name is None:
+                chinese_name = "!!!!!Fetch Chinese Name failed!!!!!"
+
+    return summary, chinese_name

--- a/animepipeline/template/bangumi.py
+++ b/animepipeline/template/bangumi.py
@@ -35,10 +35,12 @@ def get_bangumi_info(bangumi_url: str, chinese_name: Optional[str] = None) -> Tu
         if chinese_name is None:
             try:
                 chinese_name = res["name_cn"]
+                if chinese_name is None or chinese_name == "":
+                    raise ValueError("name_cn is empty")
             except Exception:
                 chinese_name = res["name"]
 
-            if chinese_name is None:
+            if chinese_name is None or chinese_name == "":
                 chinese_name = "!!!!!Fetch Chinese Name failed!!!!!"
 
     return summary, chinese_name

--- a/animepipeline/template/mediainfo.py
+++ b/animepipeline/template/mediainfo.py
@@ -4,7 +4,7 @@ from typing import List, Union
 from animepipeline.mediainfo import get_media_info
 
 
-def gen_media_info_block(video_path: Union[str, Path], uploader: str = "TensoRaws") -> str:
+def get_media_info_block(video_path: Union[str, Path], uploader: str = "TensoRaws") -> str:
     """
     Generate a code block for media info.
 

--- a/animepipeline/template/mediainfo.py
+++ b/animepipeline/template/mediainfo.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from typing import List, Union
+
+from animepipeline.mediainfo import get_media_info
+
+
+def gen_media_info_block(video_path: Union[str, Path], uploader: str = "TensoRaws") -> str:
+    """
+    Generate a code block for media info.
+
+    RELEASE.NAME........: [TensoRaws] Fate/Kaleid Liner Prisma Illya [01] [WEBRip 2160p HEVC-10bit FLAC].mkv
+    RELEASE.DATE........: 2022-07-09
+    RELEASE.SIZE........: 114514.1 GiB
+    RELEASE.FORMAT......: Matroska
+    OVERALL.BITRATE.....: 1919.8 Mb/s
+    RESOLUTION..........: 3840x2160
+    BIT.DEPTH...........: 10 bits
+    FRAME.RATE..........: 60.000 FPS
+    VIDEO...............: HEVC, Main@L5@Main
+    AUDIO#01............: Chinese, 8 channels, E-AC-3
+    AUDIO#02............: Engilsh, 2 channels, AAC
+    SUBTITLE#01.........: CHS, PGS
+    SUBTITLE#02.........: CHT, ASS
+    SUBTITLE#03.........: CHT, SRT
+    SUBTITLE#04.........: CHT&ENG, ASS
+    SUBTITLE#05.........: ENG&CHT, ASS
+    UPLOADER............: TensoRaws
+    """
+    media_info = get_media_info(video_path=video_path)
+
+    write_info_list: List[str] = []
+
+    write_info_list.append("RELEASE.NAME........: " + media_info.release_name)
+    write_info_list.append("RELEASE.DATE........: " + media_info.release_date.strftime("%Y-%m-%d"))
+    write_info_list.append("RELEASE.SIZE........: " + media_info.release_size)
+    write_info_list.append("RELEASE.FORMAT......: " + media_info.release_format)
+    write_info_list.append("OVERALL.BITRATE.....: " + media_info.overall_bitrate)
+    # VIDEO TRACK
+    write_info_list.append(
+        "RESOLUTION..........: " + str(media_info.resolution[0]) + "x" + str(media_info.resolution[1])
+    )
+    write_info_list.append("BIT.DEPTH...........: " + str(media_info.bit_depth) + " bits")
+    write_info_list.append("FRAME.RATE..........: " + str(media_info.frame_rate) + " FPS")
+    write_info_list.append("VIDEO...............: " + media_info.format + ", " + media_info.format_profile)
+    # AUDIO TRACK
+    for audio_track_id, audio_track in enumerate(media_info.audios):
+        write_info_list.append(
+            "AUDIO#"
+            + str(audio_track_id).zfill(2)
+            + "............: "
+            + audio_track[0]
+            + ", "
+            + str(audio_track[1])
+            + " channels, "
+            + audio_track[2]
+        )
+    # SUBTITLE TRACK
+    for subtitle_track_id, subtitle_track in enumerate(media_info.subtitles):
+        write_info_list.append(
+            "SUBTITLE#" + str(subtitle_track_id).zfill(2) + ".........: " + subtitle_track[0] + ", " + subtitle_track[1]
+        )
+    write_info_list.append("UPLOADER............: " + uploader)
+
+    return "\n".join(write_info_list)

--- a/animepipeline/template/mediainfo.py
+++ b/animepipeline/template/mediainfo.py
@@ -46,7 +46,7 @@ def get_media_info_block(video_path: Union[str, Path], uploader: str = "TensoRaw
     for audio_track_id, audio_track in enumerate(media_info.audios):
         write_info_list.append(
             "AUDIO#"
-            + str(audio_track_id).zfill(2)
+            + str(audio_track_id + 1).zfill(2)
             + "............: "
             + audio_track[0]
             + ", "
@@ -57,7 +57,12 @@ def get_media_info_block(video_path: Union[str, Path], uploader: str = "TensoRaw
     # SUBTITLE TRACK
     for subtitle_track_id, subtitle_track in enumerate(media_info.subtitles):
         write_info_list.append(
-            "SUBTITLE#" + str(subtitle_track_id).zfill(2) + ".........: " + subtitle_track[0] + ", " + subtitle_track[1]
+            "SUBTITLE#"
+            + str(subtitle_track_id + 1).zfill(2)
+            + ".........: "
+            + subtitle_track[0]
+            + ", "
+            + subtitle_track[1]
         )
     write_info_list.append("UPLOADER............: " + uploader)
 

--- a/animepipeline/template/template.py
+++ b/animepipeline/template/template.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+from typing import List, Optional, Union
+
+from animepipeline.template.bangumi import get_bangumi_info
+from animepipeline.template.mediainfo import get_media_info_block
+from animepipeline.util import gen_magnet_link
+
+
+def get_telegram_text(chinese_name: str, episode: int, file_name: str, torrent_file_hash: str) -> str:
+    """
+    Get telegram text.
+
+    :param chinese_name: Chinese name
+    :param episode: Episode
+    :param file_name: File name
+    :param torrent_file_hash: Torrent file hash
+    """
+    telegram_text = f"""
+✈️ -----> 正在出种...
+{chinese_name} | EP {str(episode).zfill(2)}
+{file_name}
+磁力链接 | Magnet Link:
+
+{gen_magnet_link(torrent_file_hash)}
+
+"""
+    return telegram_text
+
+
+class PostTemplate:
+    def __init__(
+        self,
+        video_path: str,
+        bangumi_url: str,
+        chinese_name: Optional[str] = None,
+        uploader: str = "TensoRaws",
+        announcement: Optional[str] = None,
+        adivertisement_images: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Initialize post template.
+
+        :param video_path: Video path
+        :param bangumi_url: Bangumi URL
+        :param chinese_name: Chinese name, default is None (auto fetch from bangumi_url)
+        :param uploader: Uploader
+        :param announcement: Announcement string
+        :param adivertisement_images: Adivertisement images
+        """
+        self.video_path = video_path
+        self.uploader = uploader
+
+        self.media_info_block = get_media_info_block(video_path=self.video_path, uploader=self.uploader)
+
+        self.bangumi_url = bangumi_url
+        self.summary, self.chinese_name = get_bangumi_info(bangumi_url=self.bangumi_url, chinese_name=chinese_name)
+
+        if announcement is not None:
+            self.announcement = announcement
+        else:
+            self.announcement = """
+资源来源于网络，感谢原资源提供者！
+本资源使用 FinalRip 分布式压制。
+
+Resources are from the internet, thanks to the original providers!
+Using FinalRip for distributed video processing.
+"""
+
+        if adivertisement_images is not None:
+            self.adivertisement_images = adivertisement_images
+        else:
+            # 招新海报，电报群，电报频道
+            self.adivertisement_images = [
+                "https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/TensoRaws%E6%8B%9B%E6%96%B0.jpg",
+                "https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/TensoRaws%E7%94%B5%E6%8A%A5%E7%BE%A4.png",
+                "https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/TensoRaws%E7%94%B5%E6%8A%A5%E9%A2%91%E9%81%93.png",
+            ]
+
+    # def html(self) -> str:
+    #     pass
+    #
+    # def markdown(self) -> str:
+    #     pass
+    #
+    # def bbcode(self) -> str:
+    #     pass
+
+    def save(
+        self,
+        html_path: Optional[Union[str, Path]],
+        markdown_path: Optional[Union[str, Path]],
+        bbcode_path: Optional[Union[str, Path]],
+    ) -> None:
+        """
+        Save the post template to file.
+
+        :param html_path: HTML file path
+        :param markdown_path: Markdown file path
+        :param bbcode_path: BBCode file path
+        """
+        pass

--- a/animepipeline/template/template.py
+++ b/animepipeline/template/template.py
@@ -47,6 +47,11 @@ class PostTemplate:
         :param announcement: Announcement string
         :param adivertisement_images: Adivertisement images, required at least 3 images, Recruitment, Telegram Group, Telegram Channel images
         """
+        if adivertisement_images is not None and len(adivertisement_images) < 3:
+            raise ValueError(
+                "Adivertisement images required at least 3 images, Recruitment, Telegram Group, Telegram Channel images"
+            )
+
         self.video_path = video_path
         self.uploader = uploader
 
@@ -109,7 +114,9 @@ Story:
 ```
 
 [招新链接 | Recruitment Link]({self.adivertisement_images[0]})
+
 [电报群链接 | Telegram Group Link]({self.adivertisement_images[1]})
+
 [电报频道链接 | Telegram Channel Link]({self.adivertisement_images[2]})
 """
 
@@ -118,17 +125,12 @@ Story:
             [f"[url={url}][img]{url}[/img][/url]" for url in self.adivertisement_images]
         )
 
-        return f"""[quote][b]
-Announcement:
-[size=3]
+        return f"""[quote][b]Announcement:[size=3]
 {self.announcement}
 [/size]
 [/b][/quote]
 
-[b][size=4]
-{self.chinese_name}
-[/size][/b]
-
+[b][size=4]{self.chinese_name}[/size][/b]
 [b]Story: [/b]
 {self.summary}
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,4 +1,4 @@
-from animepipeline.template import get_bangumi_info, get_media_info_block
+from animepipeline.template import PostTemplate, get_bangumi_info, get_media_info_block
 
 from .util import TEST_VIDEO_PATH
 
@@ -10,7 +10,19 @@ def test_get_media_info_block() -> None:
 
 
 def test_get_bangumi_info() -> None:
-    summary, chinese_name = get_bangumi_info(bangumi_url="https://bangumi.tv/subject/464376")
+    summary, chinese_name = get_bangumi_info(bangumi_url="https://bgm.tv/subject/454684")
     print(chinese_name)
     print("\n ---------------------------------- \n")
     print(summary)
+
+
+def test_post_template() -> None:
+    post_template = PostTemplate(
+        video_path=TEST_VIDEO_PATH,
+        bangumi_url="https://bgm.tv/subject/454684",
+        chinese_name="BanG Dream! Ave Mujica",
+        uploader="TensoRaws",
+    )
+    print(post_template.html())
+    print(post_template.markdown())
+    print(post_template.bbcode())

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,9 +1,16 @@
-from animepipeline.template import gen_media_info_block
+from animepipeline.template import get_bangumi_info, get_media_info_block
 
 from .util import TEST_VIDEO_PATH
 
 
-def test_gen_media_info_block() -> None:
+def test_get_media_info_block() -> None:
     print("\n")
-    media_info_block = gen_media_info_block(video_path=TEST_VIDEO_PATH)
+    media_info_block = get_media_info_block(video_path=TEST_VIDEO_PATH)
     print(media_info_block)
+
+
+def test_get_bangumi_info() -> None:
+    summary, chinese_name = get_bangumi_info(bangumi_url="https://bangumi.tv/subject/464376")
+    print(chinese_name)
+    print("\n ---------------------------------- \n")
+    print(summary)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,9 @@
+from animepipeline.template import gen_media_info_block
+
+from .util import TEST_VIDEO_PATH
+
+
+def test_gen_media_info_block() -> None:
+    print("\n")
+    media_info_block = gen_media_info_block(video_path=TEST_VIDEO_PATH)
+    print(media_info_block)

--- a/tests/test_tg.py
+++ b/tests/test_tg.py
@@ -4,6 +4,7 @@ import pytest
 
 from animepipeline.config import ServerConfig
 from animepipeline.post.tg import TGChannelSender
+from animepipeline.template import get_telegram_text
 
 from .util import CONFIG_PATH
 
@@ -14,6 +15,13 @@ video_key = "test_144p.mp4"
 async def test_tg_bot() -> None:
     server_config: ServerConfig = ServerConfig.from_yaml(CONFIG_PATH / "server.yml")
 
-    video_sender = TGChannelSender(server_config.telegram)
+    sender = TGChannelSender(server_config.telegram)
 
-    await video_sender.send_text(text="from unit test --> | 114514 哼哼啊啊啊 | test.mp4")
+    await sender.send_text(
+        text=get_telegram_text(
+            chinese_name="败犬女主太多了！",
+            episode=2,
+            file_name="[TensoRaws] Make Heroine ga Oosugiru! [02] [1080p AVC-8bit FLAC].mkv",
+            torrent_file_hash="700a6ed3967740eb02f12a3b346696b1170b20f8",
+        )
+    )


### PR DESCRIPTION
## Summary by Sourcery

Introduce a post info template generator for generating HTML, Markdown, and BBCode formatted posts. Update the pipeline to generate and save these files alongside the downloaded video.  Include the generated Telegram post text in the Telegram message.

New Features:
- Generate HTML, Markdown, and BBCode templates for posts, including media info, Bangumi information, and advertisements.

Tests:
- Add unit tests for the template generation.