### PR TITLE
fix: parse_nyaa func raise NetError

### DIFF
--- a/animepipeline/loop.py
+++ b/animepipeline/loop.py
@@ -102,7 +102,11 @@ class Loop:
             # refresh rss config
             self.rss_config.refresh_config()
             for cfg in self.rss_config.nyaa:
-                torrent_info_list = parse_nyaa(cfg)
+                try:
+                    torrent_info_list = parse_nyaa(cfg)
+                except Exception as e:
+                    logger.error(f"Failed to parse nyaa for {cfg.name}: {e}")
+                    continue
 
                 for torrent_info in torrent_info_list:
                     task_info = build_task_info(

--- a/animepipeline/rss/nyaa.py
+++ b/animepipeline/rss/nyaa.py
@@ -5,13 +5,13 @@ from typing import List
 import feedparser
 import httpx
 from loguru import logger
-from tenacity import retry, stop_after_attempt, stop_after_delay, wait_random
+from tenacity import retry, stop_after_attempt, wait_random
 
 from animepipeline.config import NyaaConfig
 from animepipeline.rss.type import TorrentInfo
 
 
-@retry(wait=wait_random(min=3, max=5), stop=stop_after_delay(10) | stop_after_attempt(30))
+@retry(wait=wait_random(min=3, max=15), stop=stop_after_attempt(10))
 def parse_nyaa(cfg: NyaaConfig) -> List[TorrentInfo]:
     rss_content = httpx.get(cfg.link).text
 


### PR DESCRIPTION
https://github.com/TensoRaws/AnimePipeline/issues/22

## Summary by Sourcery

Handle exceptions raised by the `parse_nyaa` function and log the error message instead of crashing.

Bug Fixes:
- Prevent the application from crashing when the `parse_nyaa` function raises an exception by handling the exception and logging an error message.

Enhancements:
- Improve the retry logic for the `parse_nyaa` function to wait between 3 and 15 seconds and stop after 10 attempts.