### PR TITLE
fix: tg post NetError and update docker compose deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ cython_debug/
 *.mkv
 
 /deploy/docker/
+/deploy/allinone/
 
 /store.json
 /conf/store.json

--- a/animepipeline/loop.py
+++ b/animepipeline/loop.py
@@ -269,6 +269,24 @@ class Loop:
 
         self.qbittorrent_manager.add_torrent(torrent_hash=torrent_file_hash, torrent_file_path=torrent_file_save_path)
 
+        logger.info(f"Generate all post info files for {task_info.name} EP {task_info.episode} ...")
+
+        try:
+            post_template = PostTemplate(
+                video_path=finalrip_downloaded_path,
+                bangumi_url=task_info.bangumi,  # type: ignore
+                chinese_name=task_info.translation,
+                uploader="TensoRaws",
+            )
+
+            post_template.save(
+                html_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".html"),
+                markdown_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".md"),
+                bbcode_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".txt"),
+            )
+        except Exception as e:
+            logger.error(f"Failed to generate post info files: {e}")
+
         logger.info(f"Post to Telegram Channel for {task_info.name} EP {task_info.episode} ...")
 
         if self.tg_channel_sender is None:
@@ -281,21 +299,6 @@ class Loop:
                 torrent_file_hash=torrent_file_hash,
             )
             await self.tg_channel_sender.send_text(text=tg_text)
-
-        logger.info(f"Generate all post info files for {task_info.name} EP {task_info.episode} ...")
-
-        post_template = PostTemplate(
-            video_path=finalrip_downloaded_path,
-            bangumi_url=task_info.bangumi,  # type: ignore
-            chinese_name=task_info.translation,
-            uploader="TensoRaws",
-        )
-
-        post_template.save(
-            html_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".html"),
-            markdown_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".md"),
-            bbcode_path=Path(task_info.download_path) / (finalrip_downloaded_path.name + ".txt"),
-        )
 
         # update task status
         task_status.posted = True

--- a/animepipeline/post/tg.py
+++ b/animepipeline/post/tg.py
@@ -17,7 +17,7 @@ class TGChannelSender:
         self.bot = Bot(token=config.bot_token)
         self.channel_id = config.channel_id
 
-    @retry(wait=wait_random(min=3, max=15), stop=stop_after_attempt(5))
+    @retry(wait=wait_random(min=3, max=15), stop=stop_after_attempt(10))
     async def send_text(self, text: str) -> None:
         """
         Send text to the channel.
@@ -25,7 +25,14 @@ class TGChannelSender:
         :param text: The text to send.
         """
         try:
-            await self.bot.send_message(chat_id=self.channel_id, text=text)
+            await self.bot.send_message(
+                chat_id=self.channel_id,
+                text=text,
+                read_timeout=60,
+                write_timeout=60,
+                connect_timeout=60,
+                pool_timeout=600,
+            )
         except telegram.error.NetworkError as e:
             logger.error(f"Network error: {e}, text: {text}")
             raise e

--- a/deploy/docker-compose-animepipeline.yml
+++ b/deploy/docker-compose-animepipeline.yml
@@ -2,10 +2,6 @@ version: "3.8"
 
 name: animepipeline
 
-networks:
-  backend:
-    driver: bridge
-
 services:
   animepipeline:
     image: lychee0/animepipeline:latest
@@ -13,11 +9,9 @@ services:
     volumes:
       - ./animepipeline:/app/conf
       - ./downloads:/downloads
-    networks:
-      - backend
 
   qb:
-    image: superng6/qbittorrentee:4.4.5.10
+    image: linuxserver/qbittorrent:latest
     restart: always
     environment:
       - PUID=1026
@@ -28,4 +22,21 @@ services:
     ports:
       - "6881:6881"
       - "6881:6881/udp"
+      - "48008:48008"
+      - "48008:48008/udp"
       - "8091:8080"
+#  qb-ee:
+#    image: superng6/qbittorrentee:4.4.5.10
+#    restart: always
+#    environment:
+#      - PUID=1026
+#      - PGID=100
+#    volumes:
+#      - ./allinone/qb-config:/config
+#      - ./downloads:/downloads
+#    ports:
+#      - "6881:6881"
+#      - "6881:6881/udp"
+#      - "48008:48008"
+#      - "48008:48008/udp"
+#      - "8091:8080"

--- a/deploy/docker-compose-dev.yml
+++ b/deploy/docker-compose-dev.yml
@@ -2,10 +2,6 @@ version: "3.8"
 
 name: animepipeline-dev
 
-networks:
-  backend:
-    driver: bridge
-
 services:
   qb:
     image: superng6/qbittorrentee:4.4.5.10
@@ -19,4 +15,6 @@ services:
     ports:
       - "6881:6881"
       - "6881:6881/udp"
+      - "48008:48008"
+      - "48008:48008/udp"
       - "8091:8080"


### PR DESCRIPTION
## Summary by Sourcery

Update post info generation timing and retry attempts for Telegram posts. Update qBittorrent image to `linuxserver/qbittorrent:latest` and expose additional ports.

Bug Fixes:
- Fixed a `NetworkError` issue in Telegram posts by increasing the retry attempts from 5 to 10 and adding timeouts for network requests.

Enhancements:
- Generate post information files before sending Telegram messages.

Deployment:
- Updated the Docker Compose deployment configuration to use the `linuxserver/qbittorrent:latest` image and expose ports 48008 for both TCP and UDP.