### PR TITLE
chore: replace TensoRaws org URLs with EutropicAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 auto encode new anime episode, driven by [**FinalRip**](https://github.com/EutropicAI/FinalRip)
 
-[![codecov](https://codecov.io/gh/TensoRaws/AnimePipeline/graph/badge.svg?token=CtgLouRy8u)](https://codecov.io/gh/TensoRaws/AnimePipeline)
+[![codecov](https://codecov.io/gh/EutropicAI/AnimePipeline/graph/badge.svg?token=CtgLouRy8u)](https://codecov.io/gh/TensoRaws/AnimePipeline)
 [![CI-test](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test.yml)
 [![CI-test-cli](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test-cli.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test-cli.yml)
 [![Docker Build CI](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-docker.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-docker.yml)
 [![Release](https://github.com/EutropicAI/AnimePipeline/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/animepipeline.svg)](https://badge.fury.io/py/animepipeline)
-![GitHub](https://img.shields.io/github/license/TensoRaws/AnimePipeline)
+![GitHub](https://img.shields.io/github/license/EutropicAI/AnimePipeline)
 
 ### Architecture
 
-![AnimePipeline](https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/animepipeline.png)
+![AnimePipeline](https://raw.githubusercontent.com/EutropicAI/.github/refs/heads/main/animepipeline.png)
 
 ### Installation
 
@@ -72,4 +72,4 @@ you should provide the compatible params and scripts in the [params](./conf/para
 
 ### License
 
-This project is licensed under the GPL-3.0 license - see the [LICENSE file](https://github.com/EutropicAI/AnimePipeline/blob/main/LICENSE) for details.
+This project is licensed under the GPL-3.0 license - see the [LICENSE file](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # AnimePipeline
 
-auto encode new anime episode, driven by [**FinalRip**](https://github.com/TensoRaws/FinalRip)
+auto encode new anime episode, driven by [**FinalRip**](https://github.com/EutropicAI/FinalRip)
 
 [![codecov](https://codecov.io/gh/TensoRaws/AnimePipeline/graph/badge.svg?token=CtgLouRy8u)](https://codecov.io/gh/TensoRaws/AnimePipeline)
-[![CI-test](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test.yml)
-[![CI-test-cli](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test-cli.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test-cli.yml)
-[![Docker Build CI](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-docker.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-docker.yml)
-[![Release](https://github.com/TensoRaws/AnimePipeline/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/Release.yml)
+[![CI-test](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test.yml)
+[![CI-test-cli](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test-cli.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test-cli.yml)
+[![Docker Build CI](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-docker.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-docker.yml)
+[![Release](https://github.com/EutropicAI/AnimePipeline/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/animepipeline.svg)](https://badge.fury.io/py/animepipeline)
 ![GitHub](https://img.shields.io/github/license/TensoRaws/AnimePipeline)
 
@@ -61,7 +61,7 @@ you should provide the compatible params and scripts in the [params](./conf/para
 
 ### Reference
 
-- [**FinalRip**](https://github.com/TensoRaws/FinalRip)
+- [**FinalRip**](https://github.com/EutropicAI/FinalRip)
 - [FFmpeg](https://github.com/FFmpeg/FFmpeg)
 - [VapourSynth](https://github.com/vapoursynth/vapoursynth)
 - [asyncio](https://docs.python.org/3/library/asyncio.html)
@@ -72,4 +72,4 @@ you should provide the compatible params and scripts in the [params](./conf/para
 
 ### License
 
-This project is licensed under the GPL-3.0 license - see the [LICENSE file](https://github.com/TensoRaws/AnimePipeline/blob/main/LICENSE) for details.
+This project is licensed under the GPL-3.0 license - see the [LICENSE file](https://github.com/EutropicAI/AnimePipeline/blob/main/LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ classifiers = [
   "Programming Language :: Python :: 3.13"
 ]
 description = "auto encode new anime episode"
-homepage = "https://github.com/TensoRaws/AnimePipeline"
+homepage = "https://github.com/EutropicAI/AnimePipeline"
 license = "MIT"
 name = "animepipeline"
 readme = "README.md"
-repository = "https://github.com/TensoRaws/AnimePipeline"
+repository = "https://github.com/EutropicAI/AnimePipeline"
 version = "0.0.6"
 
 # Requirements


### PR DESCRIPTION
We renamed the organization. This PR updates occurrences of:
- https://github.com/TensoRaws
to:
- https://github.com/EutropicAI

Notes:
- Only text-like files were modified; common binary/build paths skipped.
- Please review and merge when ready.
