### PR TITLE
chore: replace org URLs and LICENSE links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # AnimePipeline
 
-auto encode new anime episode, driven by [**FinalRip**](https://github.com/TensoRaws/FinalRip)
+auto encode new anime episode, driven by [**FinalRip**](https://github.com/EutropicAI/FinalRip)
 
-[![codecov](https://codecov.io/gh/TensoRaws/AnimePipeline/graph/badge.svg?token=CtgLouRy8u)](https://codecov.io/gh/TensoRaws/AnimePipeline)
-[![CI-test](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test.yml)
-[![CI-test-cli](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test-cli.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-test-cli.yml)
-[![Docker Build CI](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-docker.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/CI-docker.yml)
-[![Release](https://github.com/TensoRaws/AnimePipeline/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/AnimePipeline/actions/workflows/Release.yml)
+[![codecov](https://codecov.io/gh/EutropicAI/AnimePipeline/graph/badge.svg?token=CtgLouRy8u)](https://codecov.io/gh/EutropicAI/AnimePipeline)
+[![CI-test](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test.yml)
+[![CI-test-cli](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test-cli.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-test-cli.yml)
+[![Docker Build CI](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-docker.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/CI-docker.yml)
+[![Release](https://github.com/EutropicAI/AnimePipeline/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/AnimePipeline/actions/workflows/Release.yml)
 [![PyPI version](https://badge.fury.io/py/animepipeline.svg)](https://badge.fury.io/py/animepipeline)
-![GitHub](https://img.shields.io/github/license/TensoRaws/AnimePipeline)
+![GitHub](https://img.shields.io/github/license/EutropicAI/AnimePipeline)
 
 ### Architecture
 
-![AnimePipeline](https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/animepipeline.png)
+![AnimePipeline](https://raw.githubusercontent.com/EutropicAI/.github/refs/heads/main/animepipeline.png)
 
 ### Installation
 
@@ -61,7 +61,7 @@ you should provide the compatible params and scripts in the [params](./conf/para
 
 ### Reference
 
-- [**FinalRip**](https://github.com/TensoRaws/FinalRip)
+- [**FinalRip**](https://github.com/EutropicAI/FinalRip)
 - [FFmpeg](https://github.com/FFmpeg/FFmpeg)
 - [VapourSynth](https://github.com/vapoursynth/vapoursynth)
 - [asyncio](https://docs.python.org/3/library/asyncio.html)
@@ -72,4 +72,4 @@ you should provide the compatible params and scripts in the [params](./conf/para
 
 ### License
 
-This project is licensed under the GPL-3.0 license - see the [LICENSE file](https://github.com/TensoRaws/AnimePipeline/blob/main/LICENSE) for details.
+This project is licensed under the GPL-3.0 license - see the [LICENSE file](./LICENSE) for details.

--- a/animepipeline/bt/qb.py
+++ b/animepipeline/bt/qb.py
@@ -137,8 +137,8 @@ class QBittorrentManager:
         logger.info(f"Editing torrent file: {file_path} ...")
         new_torrent.private = False
         new_torrent.announce_urls = ANNOUNCE_URLS
-        new_torrent.comment = "Created by TensoRaws/AnimePipeline"
-        new_torrent.created_by = "TensoRaws"
+        new_torrent.comment = "Created by EutropicAI/AnimePipeline"
+        new_torrent.created_by = "EutropicAI"
         new_torrent.to_file(torrent_file_save_path)
 
         return new_torrent.info_hash

--- a/animepipeline/cli/btf/__main__.py
+++ b/animepipeline/cli/btf/__main__.py
@@ -24,7 +24,7 @@ args = parser.parse_args()
 
 def main() -> None:
     if args.UPLOADER is None:
-        args.UPLOADER = "TensoRaws"
+        args.UPLOADER = "EutropicAI"
 
     # Make torrent file
     if args.TORRENT is not None:

--- a/animepipeline/cli/rename/__main__.py
+++ b/animepipeline/cli/rename/__main__.py
@@ -23,7 +23,7 @@ def main() -> None:
     # TODO: Support withdraw of renaming
 
     if args.UPLOADER is None:
-        args.UPLOADER = "TensoRaws"
+        args.UPLOADER = "EutropicAI"
 
     path = Path(args.PATH)
 

--- a/animepipeline/loop.py
+++ b/animepipeline/loop.py
@@ -276,7 +276,7 @@ class Loop:
                 video_path=finalrip_downloaded_path,
                 bangumi_url=task_info.bangumi,  # type: ignore
                 chinese_name=task_info.translation,
-                uploader="TensoRaws",
+                uploader="EutropicAI",
             )
 
             post_template.save(

--- a/animepipeline/mediainfo/name.py
+++ b/animepipeline/mediainfo/name.py
@@ -10,9 +10,9 @@ def gen_file_name(anime_info: FileNameInfo) -> str:
     """
     Auto generate the file name, based on the media info of the file
 
-    anime_info: FileNameInfo (path: xx.mkv, episode: 1, name: Fate/Kaleid Liner Prisma Illya, uploader: TensoRaws, type: WEBRip)
+    anime_info: FileNameInfo (path: xx.mkv, episode: 1, name: Fate/Kaleid Liner Prisma Illya, uploader: EutropicAI, type: WEBRip)
 
-    -> [TensoRaws] Fate/Kaleid Liner Prisma Illya [01] [WEBRip 1080p HEVC-10bit FLAC].mkv
+    -> [EutropicAI] Fate/Kaleid Liner Prisma Illya [01] [WEBRip 1080p HEVC-10bit FLAC].mkv
 
     :param anime_info: FileNameInfo
     :return:

--- a/animepipeline/template/mediainfo.py
+++ b/animepipeline/template/mediainfo.py
@@ -4,11 +4,11 @@ from typing import List, Union
 from animepipeline.mediainfo import get_media_info
 
 
-def get_media_info_block(video_path: Union[str, Path], uploader: str = "TensoRaws") -> str:
+def get_media_info_block(video_path: Union[str, Path], uploader: str = "EutropicAI") -> str:
     """
     Generate a code block for media info.
 
-    RELEASE.NAME........: [TensoRaws] Fate/Kaleid Liner Prisma Illya [01] [WEBRip 2160p HEVC-10bit FLAC].mkv
+    RELEASE.NAME........: [EutropicAI] Fate/Kaleid Liner Prisma Illya [01] [WEBRip 2160p HEVC-10bit FLAC].mkv
     RELEASE.DATE........: 2022-07-09
     RELEASE.SIZE........: 114514.1 GiB
     RELEASE.FORMAT......: Matroska
@@ -24,7 +24,7 @@ def get_media_info_block(video_path: Union[str, Path], uploader: str = "TensoRaw
     SUBTITLE#03.........: CHT, SRT
     SUBTITLE#04.........: CHT&ENG, ASS
     SUBTITLE#05.........: ENG&CHT, ASS
-    UPLOADER............: TensoRaws
+    UPLOADER............: EutropicAI
     """
     media_info = get_media_info(video_path=video_path)
 

--- a/animepipeline/template/template.py
+++ b/animepipeline/template/template.py
@@ -33,7 +33,7 @@ class PostTemplate:
         video_path: Union[str, Path],
         bangumi_url: str,
         chinese_name: Optional[str] = None,
-        uploader: str = "TensoRaws",
+        uploader: str = "EutropicAI",
         announcement: Optional[str] = None,
         adivertisement_images: Optional[List[str]] = None,
     ) -> None:
@@ -74,9 +74,9 @@ Using FinalRip for distributed video processing."""
         else:
             # 招新海报，电报群，电报频道
             self.adivertisement_images = [
-                "https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/TensoRaws%E6%8B%9B%E6%96%B0.jpg",
-                "https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/TensoRaws%E7%94%B5%E6%8A%A5%E7%BE%A4.png",
-                "https://raw.githubusercontent.com/TensoRaws/.github/refs/heads/main/TensoRaws%E7%94%B5%E6%8A%A5%E9%A2%91%E9%81%93.png",
+                "https://raw.githubusercontent.com/EutropicAI/.github/refs/heads/main/EutropicAI%E6%8B%9B%E6%96%B0.jpg",
+                "https://raw.githubusercontent.com/EutropicAI/.github/refs/heads/main/EutropicAI%E7%94%B5%E6%8A%A5%E7%BE%A4.png",
+                "https://raw.githubusercontent.com/EutropicAI/.github/refs/heads/main/EutropicAI%E7%94%B5%E6%8A%A5%E9%A2%91%E9%81%93.png",
             ]
 
     def html(self) -> str:

--- a/conf/rss.yml
+++ b/conf/rss.yml
@@ -1,5 +1,5 @@
 base:
-  uploader: TensoRaws
+  uploader: EutropicAI
   script: default.py
   param: default.txt
   slice: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ classifiers = [
   "Programming Language :: Python :: 3.13"
 ]
 description = "auto encode new anime episode"
-homepage = "https://github.com/TensoRaws/AnimePipeline"
+homepage = "https://github.com/EutropicAI/AnimePipeline"
 license = "MIT"
 name = "animepipeline"
 readme = "README.md"
-repository = "https://github.com/TensoRaws/AnimePipeline"
+repository = "https://github.com/EutropicAI/AnimePipeline"
 version = "0.0.6"
 
 # Requirements

--- a/tests/test_mediainfo.py
+++ b/tests/test_mediainfo.py
@@ -16,11 +16,11 @@ def test_gen_file_name() -> None:
         path=str(TEST_VIDEO_PATH),
         episode=1,
         name="test 114",
-        uploader="TensoRaws",
+        uploader="EutropicAI",
     )
 
     name = gen_file_name(anime_info=anime_info)
-    assert name == "[TensoRaws] test 114 [01] [WEBRip 144p AVC-8bit AAC].mp4"
+    assert name == "[EutropicAI] test 114 [01] [WEBRip 144p AVC-8bit AAC].mp4"
 
 
 def test_rename_file() -> None:
@@ -32,8 +32,8 @@ def test_rename_file() -> None:
         path=str(ASSETS_PATH / "copy_test_144p.mp4"),
         episode=1,
         name="test 114",
-        uploader="TensoRaws",
+        uploader="EutropicAI",
     )
 
     p = rename_file(anime_info=anime_info)
-    assert p.name == "[TensoRaws] test 114 [01] [WEBRip 144p AVC-8bit AAC].mp4"
+    assert p.name == "[EutropicAI] test 114 [01] [WEBRip 144p AVC-8bit AAC].mp4"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -21,7 +21,7 @@ def test_post_template() -> None:
         video_path=TEST_VIDEO_PATH,
         bangumi_url="https://bgm.tv/subject/454684",
         chinese_name="BanG Dream! Ave Mujica",
-        uploader="TensoRaws",
+        uploader="EutropicAI",
     )
     print(post_template.html())
     print(post_template.markdown())

--- a/tests/test_tg.py
+++ b/tests/test_tg.py
@@ -19,7 +19,7 @@ async def test_tg_bot() -> None:
         text=get_telegram_text(
             chinese_name="from unit test ~~~  |  败犬女主太多了！",
             episode=2,
-            file_name="[TensoRaws] Make Heroine ga Oosugiru! [02] [1080p AVC-8bit FLAC].mkv",
+            file_name="[EutropicAI] Make Heroine ga Oosugiru! [02] [1080p AVC-8bit FLAC].mkv",
             torrent_file_hash="this_is_a_fake_hash",
         )
     )


### PR DESCRIPTION
This PR updates explicit org URLs and converts absolute LICENSE links to relative form.

Org URL replacements: 41
LICENSE link conversions (blob): 1
LICENSE link conversions (raw): 0

Old base: TensoRaws
New base: EutropicAI

Relative ./LICENSE links stay correct if branches or hosts change.